### PR TITLE
Highlight the selected filter

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -217,6 +217,7 @@ function createButton(title, count){
 		.not('button.profile-questions-filter--isActive')
 		.first()
 		.clone();
+	newButton.addClass('user-defined-filter');
 	newButton.children(`.profile-questions-filter-title`).text(title);
 	newButton.children(`.profile-questions-filter-icon`).remove();
 	if(!count){
@@ -251,7 +252,7 @@ function applyFilter(category){
 }
 
 function deselectCategoriesVisually(){
-	jq('button.profile-questions-filter').removeClass('profile-questions-filter--isActive');
+	jq('button.profile-questions-filter.user-defined-filter').removeClass('profile-questions-filter--isActive');
 }
 
 function selectCategoryVisually(category){

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -244,8 +244,22 @@ function addNewFilterButton(){
 function applyFilter(category){
 	alert(`Applying filter ${category}`);
 	currentFilter = category;
+	deselectCategoriesVisually();
+	selectCategoryVisually(currentFilter);
 	
 	manipulateQuestionElements();
+}
+
+function deselectCategoriesVisually(){
+	jq('button.profile-questions-filter').removeClass('profile-questions-filter--isActive');
+}
+
+function selectCategoryVisually(category){
+	let selectedButton = jq('button.profile-questions-filter').filter(function() {
+		console.log(jq(this));
+		return jq(this).children(`.profile-questions-filter-title`).first().text() == category;
+	})
+	selectedButton.addClass('profile-questions-filter--isActive');
 }
 
 function getQuestions(){


### PR DESCRIPTION
Fixes #15 

Manipulates the elements to get the class that the OKCupid CSS uses to show the filter indicator. When a user-defined filter is selected, it receives the necessary class. When a different filter is selected, it loses it.

This does not touch the default agree/disagree/find out filters. In the normal case where one of those is selected, you'll see two indicators: one for the question listed as filtered by OKCupid (agree/disagree/find out) and another for additional filtering performed by this extension.