### PR TITLE
Update categorization elements when changing filters

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -139,9 +139,8 @@ function addBorder(questionElement, color){
 }
 
 function addCategorizationButtons(questionElement){
-	if(questionElement.find('.questionCategorization').length > 0){
-		return;
-	}
+	questionElement.find('.questionCategorization').remove();
+	
 	const instructions = `Is this a ${currentFilter} question?`;
 	const instructionsElement = `<span class="filterInstructions"><h4>${instructions}</h4></span>`;
 	


### PR DESCRIPTION
This removes the existing buttons/instructions when we manipulate the page's questions. (This is most common when switching filters, but also when the page loads/changes or when categorization occurs.) The code will then proceed to add new elements for the current filter. It was previously skipping the new buttons in this scenario, as the original implementation just added another set, and you ended up with multiple buttons per question. With this change we instead tear the old elements down and add new ones instead of leaving the old, now wrong, ones up.