### PR TITLE
Display Question Counts for each filter

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -259,7 +259,6 @@ function deselectCategoriesVisually(){
 
 function selectCategoryVisually(category){
 	let selectedButton = jq('button.profile-questions-filter').filter(function() {
-		console.log(jq(this));
 		return jq(this).children(`.profile-questions-filter-title`).first().text() == category;
 	})
 	selectedButton.addClass('profile-questions-filter--isActive');

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -236,18 +236,23 @@ function updateFilterCounts(){
 		const filterName = thisFilter.children('span.profile-questions-filter-title').first().text();
 		const questionsInCategory = getQuestionsInCategory(filterName);
 		const questionsThatCurrentlyMatch = getNumberOfLoadedQuestionsInCategory(questionsInCategory);
+		const questionsUndecidedInCategory = getQuestionsWithCategoryUndecided(filterName);
+		const questionsThatCurrentlyMightMatch = getNumberOfLoadedQuestionsInCategory(questionsUndecidedInCategory);
 		const numUnloaded = getNumberOfUnloadedQuestionsFromUser();
 		
+		let possible = questionsThatCurrentlyMatch + questionsThatCurrentlyMightMatch;
 		let result;
 		if(numUnloaded === -1){
 			result = `${questionsThatCurrentlyMatch}+`;
 		}
-		else if(numUnloaded === 0){
-			result = `${questionsThatCurrentlyMatch}`;
-		}
-		else{
-			let possible = questionsThatCurrentlyMatch + numUnloaded;
-			result = `${questionsThatCurrentlyMatch}-${possible}`;
+		else {
+			possible += numUnloaded;
+			if(questionsThatCurrentlyMatch === possible){
+				result = `${questionsThatCurrentlyMatch}`;
+			}
+			else{
+				result = `${questionsThatCurrentlyMatch}-${possible}`;
+			}
 		}
 		thisFilter.children(`.profile-questions-filter-count`).text(`${result}`);
 	});
@@ -350,6 +355,12 @@ function getQuestionsNotInCategory(category){
 function getQuestionTextsByCategoryAndValue(questions, category, value){
 	return questions.filter(q => q[category] === value)
 		.map(q => q.QuestionText);
+}
+
+function getQuestionsWithCategoryUndecided(category){
+	return questions.filter(function(q){
+		return !(category in q);
+	}).map(q => q.QuestionText);
 }
 
 function isQuestionDefined(questions, questionText){


### PR DESCRIPTION
Fixes #6 

Edits the count element whenever we manipulate the page. If a filter has undecided questions or if there are more questions off screen, a range is shown from the number we know match to the number of theoretical matches, which would be if all the undecided questions are categorized as matching and if all the offscreen questions are loaded and happen to match/be undecided as well.

We do have an edge case when the user is not on one of OKCupid's main three built-in filters, e.g. filter_id=1 or 8. We have no way to know how many questions are on the fully loaded page, so we can't compute an upper bound. Knowing if the page was fully scrolled would help, but that's beyond my current skills and the necessary scope of this ticket to learn. In this case I'll show the number that match with a 'plus', e.g. '4+'. We know there are four. There could be more, but we can't say how many. I considered putting the undecided count in for a range, but it's still not an upper bound, and '2-37+' is not a particularly clear value. (2 known, 35 undecided, some number off screen)

Verified that the counts are present at the beginning and adjust as we scroll and questions are loaded, including when switching between built-in filters. Verified counts were what I was expecting as I could. Verified counts updated as questions were categorized.