### PR TITLE
Tweaks to displaying question counts for each filter

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -202,20 +202,20 @@ function listenForQuestionListUpdates(){
 
 function createFilterButtons() {
 	for(const category of questionCategories){
-		addFilterButton(category, 123);
+		addFilterButton(category);
 	}
 	addNewFilterButton();
 }
 
-function addFilterButton(category, count){
-	let newButton = createButton(category, count);
+function addFilterButton(category){
+	let newButton = createButton(category);
 	newButton.click(() => {
 		applyFilter(category);
 	});
 	addButton(newButton);
 }
 
-function createButton(title, count){
+function createButton(title){
 	let newButton = jq('button.profile-questions-filter')
 		.not('button.profile-questions-filter--isActive')
 		.first()
@@ -223,10 +223,7 @@ function createButton(title, count){
 	newButton.addClass('user-defined-filter');
 	newButton.children(`.profile-questions-filter-title`).text(title);
 	newButton.children(`.profile-questions-filter-icon`).remove();
-	if(!count){
-		count = "";
-	}
-	newButton.children(`.profile-questions-filter-count`).text(`${count}`);
+	newButton.children(`.profile-questions-filter-count`).text("");
 	return newButton;
 }
 
@@ -267,7 +264,7 @@ function addNewFilterButton(){
 	newFilterButton.click(() => {
 		 var newFilterName = prompt("Enter the name of the new filter");
 		 if(newFilterName){
-			 addFilterButton(newFilterName, 0);
+			addFilterButton(newFilterName);
 		 }
 	});
 	addButton(newFilterButton);

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -265,6 +265,7 @@ function addNewFilterButton(){
 		 var newFilterName = prompt("Enter the name of the new filter");
 		 if(newFilterName){
 			addFilterButton(newFilterName);
+			manipulateQuestionElements();
 		 }
 	});
 	addButton(newFilterButton);

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -268,6 +268,7 @@ function addNewFilterButton(){
 			manipulateQuestionElements();
 		 }
 	});
+	newFilterButton.removeClass('user-defined-filter');
 	addButton(newFilterButton);
 }
 


### PR DESCRIPTION
Fixes a couple minor bugs and cleans up the code a bit. Specifically, the "Add New Filter" button shouldn't get a count as it's not really a filter. And if it's clicked and a new filter is created, it should get a count immediately.