### PR TITLE
Categorization elements refresh each time

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -114,25 +114,30 @@ function manipulateQuestionElements(){
 }
 
 function manipulateDefaultBehaviorQuestion(questionElement){
+	resetQuestionDisplay(questionElement);
 	questionElement.show();
 	addBorder(questionElement, 'black');
 }
 
 function manipulateLoadingQuestion(questionElement){
+	resetQuestionDisplay(questionElement);
 	questionElement.show();
 	addBorder(questionElement, 'green');
 }
 
 function manipulateDesiredQuestion(questionElement){
+	resetQuestionDisplay(questionElement);
 	questionElement.show();
 	addBorder(questionElement, 'blue');
 }
 
 function manipulateUndesiredQuestion(questionElement){
+	resetQuestionDisplay(questionElement);
 	questionElement.hide();
 }
 
 function manipulateUndecidedQuestion(questionElement){
+	resetQuestionDisplay(questionElement);
 	questionElement.show();
 	addBorder(questionElement, 'red');
 	addCategorizationButtons(questionElement);
@@ -144,12 +149,15 @@ function manipulateUndecidedQuestion(questionElement){
 	}
 }
 
+function resetQuestionDisplay(questionElement){
+	questionElement.find('.questionCategorization').remove();
+}
+
 function addBorder(questionElement, color){
 	questionElement.css('border', `3px solid ${color}`)
 }
 
 function addCategorizationButtons(questionElement){
-	questionElement.find('.questionCategorization').remove();
 	
 	const instructions = `Is this a ${currentFilter} question?`;
 	const instructionsElement = `<span class="filterInstructions"><h4>${instructions}</h4></span>`;


### PR DESCRIPTION
Any time we re-manipulate questions, we now remove the categorization instructions/button elements. Depending on the situation, they may remain removed, be recreated identically, or be recreated with different instructions/behavior moments later. This is frequent as the page loads or decisions are made. I haven't noticed any performance issues yet, but optimizations are definitely possible here and throughout.

We used to add the categorization elements to a question whenever an undecided question was encountered. That led to a bug (pre-github issues) of having multiple elements when you find the same question in a second undecided filter. That was solved by skipping the question and introduced #9. Now questions only got one set of categorization elements, but it was decided one time only when it was first encountered as an undecided question. It would stick around regardless of filter. If found undecided again, the text was still for the old filter. If found decided, the elements were still there with the text for the old filter. (The buttons always worked on the new filter though.) The next attempt to fix this, #23, removed/replaced the elements in the specific case of encountering the question as undecided. This adds that remove/replace logic to _any_ time the question is encountered again, most importantly if it's encountered in a different filter as matching (blue). The elements are removed, and they are not necessary to re-add in this case. In the undecided case, they will continue to be removed, and a new undecided filter will continue to recreate the buttons for the new filter.

I also added this reset action for the other question states: loading, default, and undesired. They're unnecessary right now, but I'd rather have the consistency, and I'm unsure if they'll stay unnecessary. If we should implement a feature to turn off a user-defined filter and have the questions go back to default, this would be desired then. And I'm not sure if it won't be valuable for undesired to depending on the result of #7, which might display undesired questions.