### PR TITLE
Allow the user to delete a filter

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -213,6 +213,7 @@ function createFilterButtons() {
 		addFilterButton(category);
 	}
 	addNewFilterButton();
+	addDeleteFilterButton();
 }
 
 function addFilterButton(category){
@@ -281,6 +282,22 @@ function addNewFilterButton(){
 	addButton(newFilterButton);
 }
 
+function addDeleteFilterButton(){
+	let deleteFilterButton = createButton("Delete filter", false);
+	deleteFilterButton.click(() => {
+		var deleteFilterName = prompt("Warning: This cannot be reversed and you will lose your filter's configuration! Enter the name of the filter to delete:");
+		if(deleteFilterName){
+			removeFilterButtonFromScreen(deleteFilterName);
+		}
+	});
+	addButton(deleteFilterButton);
+}
+
+function removeFilterButtonFromScreen(deleteFilterName){
+	let $button = findFilterButtonByName(deleteFilterName);
+	$button.remove();
+}
+
 function applyFilter(category){
 	alert(`Applying filter ${category}`);
 	currentFilter = category;
@@ -295,10 +312,15 @@ function deselectCategoriesVisually(){
 }
 
 function selectCategoryVisually(category){
-	let selectedButton = jq('button.profile-questions-filter').filter(function() {
-		return jq(this).children(`.profile-questions-filter-title`).first().text() == category;
-	})
+	let selectedButton = findFilterButtonByName(category);
 	selectedButton.addClass('profile-questions-filter--isActive');
+}
+
+function findFilterButtonByName(filterName){
+	let selectedButton = jq('button.user-defined-filter').filter(function() {
+		return jq(this).children(`.profile-questions-filter-title`).first().text().toUpperCase() == filterName.toUpperCase();
+	})
+	return selectedButton;
 }
 
 // Agree/Disagree/Find Out - whichever is selected. If none are selected, -1. 

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -287,15 +287,18 @@ function addDeleteFilterButton(){
 	deleteFilterButton.click(() => {
 		var deleteFilterName = prompt("Warning: This cannot be reversed and you will lose your filter's configuration! Enter the name of the filter to delete:");
 		if(deleteFilterName){
-			removeFilterButtonFromScreen(deleteFilterName);
+			let $filterElement = findFilterButtonByName(deleteFilterName);
+			if($filterElement.length > 0){
+				let correctlyCasedFilterName = $filterElement.children(`.profile-questions-filter-title`).first().text();
+				removeFilterButtonFromScreen($filterElement);
+			}
 		}
 	});
 	addButton(deleteFilterButton);
 }
 
-function removeFilterButtonFromScreen(deleteFilterName){
-	let $button = findFilterButtonByName(deleteFilterName);
-	$button.remove();
+function removeFilterButtonFromScreen($filterElement){
+	$filterElement.remove();
 }
 
 function applyFilter(category){

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -291,6 +291,7 @@ function addDeleteFilterButton(){
 			if($filterElement.length > 0){
 				let correctlyCasedFilterName = $filterElement.children(`.profile-questions-filter-title`).first().text();
 				removeFilterButtonFromScreen($filterElement);
+				deleteFilterFromQuestions(correctlyCasedFilterName);
 			}
 			else{
 				alert(`Unable to find filter named ${deleteFilterName}`);
@@ -302,6 +303,18 @@ function addDeleteFilterButton(){
 
 function removeFilterButtonFromScreen($filterElement){
 	$filterElement.remove();
+}
+
+function deleteFilterFromQuestions(filterName){
+	let questionsWithFilterSet = getQuestionObjectsWithCategoryDecided(filterName);
+	if(questionsWithFilterSet.length > 0){
+		for(question of questionsWithFilterSet){
+			delete question[filterName];
+		}
+		saveQuestions(questions);
+		questionCategories.delete(filterName);
+		alert(`The '${filterName}' filter has been deleted`);
+	}
 }
 
 function applyFilter(category){
@@ -391,6 +404,12 @@ function getQuestionsNotInCategory(category){
 function getQuestionTextsByCategoryAndValue(questions, category, value){
 	return questions.filter(q => q[category] === value)
 		.map(q => q.QuestionText);
+}
+
+function getQuestionObjectsWithCategoryDecided(category){
+	return questions.filter(function(q){
+		return (category in q);
+	});
 }
 
 function getQuestionsWithCategoryUndecided(category){

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -216,22 +216,24 @@ function createFilterButtons() {
 }
 
 function addFilterButton(category){
-	let newButton = createButton(category);
+	let newButton = createButton(category, true);
 	newButton.click(() => {
 		applyFilter(category);
 	});
 	addButton(newButton);
 }
 
-function createButton(title){
+function createButton(title, isAFilter){
 	let newButton = jq('button.profile-questions-filter')
 		.not('button.profile-questions-filter--isActive')
 		.first()
 		.clone();
-	newButton.addClass('user-defined-filter');
 	newButton.children(`.profile-questions-filter-title`).text(title);
 	newButton.children(`.profile-questions-filter-icon`).remove();
 	newButton.children(`.profile-questions-filter-count`).text("");
+	if(isAFilter){
+		newButton.addClass('user-defined-filter');
+	}
 	return newButton;
 }
 
@@ -268,7 +270,7 @@ function addButton(button){
 }
 
 function addNewFilterButton(){
-	let newFilterButton = createButton("Add new filter");
+	let newFilterButton = createButton("Add new filter", false);
 	newFilterButton.click(() => {
 		 var newFilterName = prompt("Enter the name of the new filter");
 		 if(newFilterName){
@@ -276,7 +278,6 @@ function addNewFilterButton(){
 			manipulateQuestionElements();
 		 }
 	});
-	newFilterButton.removeClass('user-defined-filter');
 	addButton(newFilterButton);
 }
 

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -292,6 +292,9 @@ function addDeleteFilterButton(){
 				let correctlyCasedFilterName = $filterElement.children(`.profile-questions-filter-title`).first().text();
 				removeFilterButtonFromScreen($filterElement);
 			}
+			else{
+				alert(`Unable to find filter named ${deleteFilterName}`);
+			}
 		}
 	});
 	addButton(deleteFilterButton);


### PR DESCRIPTION
Fixes #11 

Adds a "Delete Filter" button to the page. When selected, prompts the user for the name of the filter. (Not case sensitive. It's too much to expect given that the page CSS is converting to upper case.) If it doesn't exist, returns an error alert. Otherwise it removes the filter from the screen and finds all questions where the filter is decided and removes the decision. Next time we load we won't dynamically find it without any questions having a decision.

Note: If the filter was previously selected, it will remain selected. `currentFilter` remains set. (Unsetting it is unsupported. I don't know what would happen.) Categorization buttons that are visible might bring it back. I haven't tried.