### PR TITLE
Add an edit mode/button to change questions' categorization

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -101,7 +101,7 @@ function manipulateQuestionElements(){
 		const isWantedQuestion = questionsInCategory.includes(questionText);
 		const isUndecidedQuestion = !isUnwantedQuestion && !isWantedQuestion;
 		if(inEditMode || isUndecidedQuestion){
-			addCategorizationButtons(thisQuestion);
+			addCategorizationButtons(thisQuestion, isWantedQuestion, isUnwantedQuestion);
 			thisQuestion.show();
 		}
 		else if(isUnwantedQuestion){
@@ -117,7 +117,7 @@ function resetQuestionDisplay(questionElement){
 	questionElement.find('.questionCategorization').remove();
 }
 
-function addCategorizationButtons(questionElement){
+function addCategorizationButtons(questionElement, wanted, unwanted){
 	
 	const instructions = `Is this a ${currentFilter} question?`;
 	const instructionsElement = `<span class="filterInstructions"><h4>${instructions}</h4></span>`;
@@ -139,6 +139,13 @@ function addCategorizationButtons(questionElement){
 	notInFilterButtonElement.click(() => {
 		questionDoesNotBelongInFilter(questionElement);
 	});
+	
+	if(wanted){
+		notInFilterButtonElement.css('opacity', '0.5');
+	}
+	else if(unwanted){
+		inFilterButtonElement.css('opacity', '0.5');
+	}
 }
 
 function questionBelongsInFilter(thisQuestion){

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -141,12 +141,6 @@ function manipulateUndecidedQuestion(questionElement){
 	questionElement.show();
 	addBorder(questionElement, 'red');
 	addCategorizationButtons(questionElement);
-	
-	const questionText = questionElement.find('h3').text();
-	if(!isQuestionDefined(questions, questionText)){
-		addQuestion(questions, questionText);
-		saveQuestions(questions);
-	}
 }
 
 function resetQuestionDisplay(questionElement){
@@ -390,7 +384,12 @@ function getQuestions(){
 }
 
 function getQuestionByText(questions, text){
-	return questions.find(q => q.QuestionText === text);
+	let question = questions.find(q => q.QuestionText === text);
+	if(!question){
+		question = addQuestion(questions, text);
+		saveQuestions(questions);
+	}
+	return question;
 }
 
 function getQuestionsInCategory(category){
@@ -418,14 +417,11 @@ function getQuestionsWithCategoryUndecided(category){
 	}).map(q => q.QuestionText);
 }
 
-function isQuestionDefined(questions, questionText){
-	return getQuestionByText(questions, questionText) !== undefined;
-}
-
 function addQuestion(questions, questionText){
 	let newQuestion = {};
 	newQuestion["QuestionText"] = questionText;
 	questions.push(newQuestion);
+	return newQuestion;
 }
 
 const saveQuestions = _.debounce(function(questions) {

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -83,15 +83,15 @@ function isPageLoaded(selector){
 
 function manipulateQuestionElements(){
 	updateFilterCounts();
-	if(!currentFilter){
-		manipulateDefaultBehaviorQuestion(jq(`div.profile-question`));
-		return;
-	}
 	
 	let questionsInCategory = getQuestionsInCategory(currentFilter);
 	let questionsNotInCategory = getQuestionsNotInCategory(currentFilter);
 	jq('div.profile-question').each(function(index){
 		const thisQuestion = jq(this) // when jq.each is run, it calls the callback and sets the 'this' context when running to the DOM item
+		if(!currentFilter){
+			manipulateDefaultBehaviorQuestion(thisQuestion);
+			return;
+		}
 		const isLoaded = !thisQuestion.hasClass('isLoading');
 		if(!isLoaded){
 			manipulateLoadingQuestion(thisQuestion);
@@ -393,10 +393,16 @@ function getQuestionByText(questions, text){
 }
 
 function getQuestionsInCategory(category){
+	if(!category){
+		return questions.map(q => q.QuestionText);
+	}
 	return getQuestionTextsByCategoryAndValue(questions, category, "TRUE");
 }
 
 function getQuestionsNotInCategory(category){
+	if(!category){
+		return [];
+	}
 	return getQuestionTextsByCategoryAndValue(questions, category, "FALSE");
 }
 

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -102,6 +102,8 @@ function manipulateQuestionElements(){
 		const isUndecidedQuestion = !isUnwantedQuestion && !isWantedQuestion;
 		if(inEditMode || isUndecidedQuestion){
 			addCategorizationButtons(thisQuestion, isWantedQuestion, isUnwantedQuestion);
+			thisQuestion.css('border', `2px dashed gray`)
+
 			thisQuestion.show();
 		}
 		else if(isUnwantedQuestion){
@@ -115,6 +117,7 @@ function manipulateQuestionElements(){
 
 function resetQuestionDisplay(questionElement){
 	questionElement.find('.questionCategorization').remove();
+	questionElement.css('border', ``)
 }
 
 function addCategorizationButtons(questionElement, wanted, unwanted){


### PR DESCRIPTION
Fixes #7 
Fixes #14

Adds an "Edit Filter" button to the filter list. When a valid filter name is entered, switches to that filter but shows every question (whether previously matching, not matching, or undecided) with the categorization instructions and buttons. Choices may be set or changed using the buttons. Clicking the buttons changes the screen only minimally in edit mode; all questions will remain shown. Questions that are being edited or are undecided in the normal flow will be shown with a subtle dashed border. Other borders were removed. In edit mode, the current state of the question is shown by adjusting the categorization buttons' opacities. The current state is shown at 100% while the rejected option is faded out at 50% opacity.

I verified the buttons update counts, are persisted, and in the non-edit mode will continue to have their effects rendered immediately (removing elements and/or hiding). I verified you can enter and exit edit mode seamlessly by selecting it and the normal filters in any order.