### PR TITLE
When on the hidden public filter, use the total question count as the upper bound

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -342,6 +342,17 @@ function findFilterButtonByName(filterName){
 	return selectedButton;
 }
 
+function getTotalNumberOfQuestionsAnsweredByUser(){
+	let count = 0;
+	let $countElements = jq('button.profile-questions-filter')
+		.not('button.user-defined-filter')
+		.children('span.profile-questions-filter-count');
+	$countElements.each(function(index){
+		count += Number(jq(this).text());
+	});
+	return count;
+}
+
 // Agree/Disagree/Find Out - whichever is selected. If none are selected, -1. 
 // (This is probably because the url was changed to have a filter_id that's not 9, 10, or 11. We don't know how many questions are coming.
 function getNumberOfQuestionsInSelectedDefaultFilter(){
@@ -361,11 +372,16 @@ function getNumberOfLoadedQuestionsFromUser(){
 	return jq('div.profile-question').length;
 }
 
-// Number of questions that are still offscreen. -1 if we don't know the size of the current default filter.
+// Number of questions that are still offscreen. -1 if we don't know the size of the currently loaded page.
 function getNumberOfUnloadedQuestionsFromUser(){
 	let totalOnPage = getNumberOfQuestionsInSelectedDefaultFilter();
 	if(totalOnPage === -1){
-		return -1;
+		if(isOnPublicFilter()){
+			totalOnPage = getTotalNumberOfQuestionsAnsweredByUser();
+		}
+		else{
+			return -1;
+		}
 	}
 	return totalOnPage - getNumberOfLoadedQuestionsFromUser();
 }
@@ -443,5 +459,11 @@ const saveQuestions = _.debounce(function(questions) {
 	});
 	return savePromise.catch(logFailureResponse).then(logSuccessResponse);
 }, 5000);
+
+function isOnPublicFilter(){
+	const urlParams = new URLSearchParams(window.location.search);
+	const filterId = urlParams.get('filter_id');
+	return Number(filterId) === 1;
+}
 
 })();

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -214,23 +214,23 @@ function updateFilterCounts(){
 		const thisFilter = jq(this);
 		const filterName = thisFilter.children('span.profile-questions-filter-title').first().text();
 		const questionsInCategory = getQuestionsInCategory(filterName);
-		const questionsThatCurrentlyMatch = getNumberOfLoadedQuestionsInCategory(questionsInCategory);
+		const countOfQuestionsThatCurrentlyMatch = getNumberOfLoadedQuestionsInCategory(questionsInCategory);
 		const questionsUndecidedInCategory = getQuestionsWithCategoryUndecided(filterName);
-		const questionsThatCurrentlyMightMatch = getNumberOfLoadedQuestionsInCategory(questionsUndecidedInCategory);
+		const countOfQuestionsThatCurrentlyMightMatch = getNumberOfLoadedQuestionsInCategory(questionsUndecidedInCategory);
 		const numUnloaded = getNumberOfUnloadedQuestionsFromUser();
 		
-		let possible = questionsThatCurrentlyMatch + questionsThatCurrentlyMightMatch;
+		let possible = countOfQuestionsThatCurrentlyMatch + countOfQuestionsThatCurrentlyMightMatch;
 		let result;
 		if(numUnloaded === -1){
-			result = `${questionsThatCurrentlyMatch}+`;
+			result = `${countOfQuestionsThatCurrentlyMatch}+`;
 		}
 		else {
 			possible += numUnloaded;
-			if(questionsThatCurrentlyMatch === possible){
-				result = `${questionsThatCurrentlyMatch}`;
+			if(countOfQuestionsThatCurrentlyMatch === possible){
+				result = `${countOfQuestionsThatCurrentlyMatch}`;
 			}
 			else{
-				result = `${questionsThatCurrentlyMatch}-${possible}`;
+				result = `${countOfQuestionsThatCurrentlyMatch}-${possible}`;
 			}
 		}
 		thisFilter.children(`.profile-questions-filter-count`).text(`${result}`);


### PR DESCRIPTION
Fixes #26 

If (and only if) the user is on the public filter, which is filter_id=1 (this is undocumented behavior of okcupid, found by trial and error - see https://github.com/ojchase/OKCupidQuestionFilterExtension/wiki/Filter-ID-on-OKCupid-queries), then we can calculate the possible number of questions. It should be a sum of the agree/disagree/find out filters. (Or at least I've never seen a discrepancy.) Having a deterministic total count allows us to use the existing question count logic to show a range of questions that would be in the user-defined filter.

If on any other filter than 1, 9, 10, or 11, we really have no idea how many questions will appear. The 'matchcount +' that displays now (see #6) is the best we can do.