### PR TITLE
Detect page changes and load filters when on a question page

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -56,24 +56,13 @@ function manipulatePage(){
 //See https://stackoverflow.com/questions/20865581/chrome-extension-content-script-not-loaded-until-page-is-refreshed
 async function waitForPageToLoad(selector){
 	return new Promise(async (resolve,reject) => {
-		let loaded = false;
-		let timedOut = false;
-		const timeoutId = window.setTimeout(()=>{
-			if(loaded){
-				return;
-			}
-			timedOut = true;
-			reject();
-		},30000);
-		while(!isPageLoaded(selector) && !timedOut){
+		while(!isPageLoaded(selector)){
 			await new Promise((resolveSimpleTimeout) => {
 				window.setTimeout(() => {
 					resolveSimpleTimeout();
 				}, 500);
 			});
 		}
-		window.clearTimeout(timeoutId);
-		loaded = true;
 		resolve();
 	});
 }

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -12,6 +12,8 @@ let inEditMode = false;
 var jq = jQuery.noConflict();
 loadQuestionData().then(function(){
 	jq(document).ready(() => {
+		document.body.style.border = "5px solid red";
+		listenForPageChanges();
 		manipulatePage();
 	});
 });
@@ -38,26 +40,30 @@ function logFailureResponse(response){
 	console.log(response);
 }
 
+// Note that the current design has this script active on all okcupid.com pages.
 function manipulatePage(){
-	document.body.style.border = "5px solid red";
-	
 	waitForPageToLoad('.page-loading, .isLoading').then(function(){
 		document.body.style.border = "5px solid blue";
-		listenForQuestionListUpdates();
-		createFilterButtons();
-		manipulateQuestionElements();
-	}).catch((e) => {
-		console.log("It's not loaded!")
-		console.log(e);
+		if(isOnAQuestionPage()){
+			listenForQuestionListUpdates();
+			createFilterButtons();
+			manipulateQuestionElements();
+		}
 	});
 }
 
+let currentUrl = location.href;
+function listenForPageChanges(){
+	// Thanks to https://stackoverflow.com/a/1930942
+	setInterval(function() {
+		if(window.location.href != currentUrl) {
+			currentUrl = window.location.href;
+			document.body.style.border = "5px solid red";
+			manipulatePage();
+		}
+	}, 3000);
+}
 
-// Promise
-//Note that the current design has this script active on all okcupid.com pages,
-//not just the questions page, as I can't detect the questions page being up if
-//it was launched via okcupid internal links.
-//See https://stackoverflow.com/questions/20865581/chrome-extension-content-script-not-loaded-until-page-is-refreshed
 async function waitForPageToLoad(selector){
 	return new Promise(async (resolve,reject) => {
 		while(!isPageLoaded(selector)){
@@ -457,6 +463,10 @@ function isOnPublicFilter(){
 	const urlParams = new URLSearchParams(window.location.search);
 	const filterId = urlParams.get('filter_id');
 	return Number(filterId) === 1;
+}
+
+function isOnAQuestionPage(){
+	return window.location.href.includes("/questions");
 }
 
 })();


### PR DESCRIPTION
Fixes #10 

This adds detection for when the URL is changing because the user thinks he's navigating to a new page on the site, but it's really reusing the same one and making dynamic changes. If the user is on a question page, I go into the normal logic to manipulate the page. If not, I just wait until the next URL change.

I also removed the timeout. This is fundamentally a polling mechanism, but the performance hasn't been a problem, and I need the extension to remain running without requiring page refreshes no matter which page we're on or how long we've been there.