### PR TITLE
Correctly parse question counts over 999

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -347,7 +347,9 @@ function getTotalNumberOfQuestionsAnsweredByUser(){
 		.not('button.user-defined-filter')
 		.children('span.profile-questions-filter-count');
 	$countElements.each(function(index){
-		count += Number(jq(this).text());
+		let countString = jq(this).text();
+		countString = countString.replace(/,/g, ''); // remove commas, which OKCupid has. This probably does not internationalize. My locale has commas, e.g. 1,234 questions
+		count += Number(countString);
 	});
 	return count;
 }


### PR DESCRIPTION
Fixes #34 

Remove commas from counts before parsing the number.

I did not see any satisfactory appraoches to this on https://stackoverflow.com/questions/11665884/how-can-i-parse-a-string-with-a-comma-thousand-separator-to-a-number that really internationalize well without bringing in libraries. This will work in the US where counts greater than a thousand appear as 1,234. PRs with better approaches are welcome.