### PR TITLE
Reset filter state between pages

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -42,6 +42,8 @@ function logFailureResponse(response){
 
 // Note that the current design has this script active on all okcupid.com pages.
 function manipulatePage(){
+	currentFilter = undefined;
+	inEditMode = false;
 	waitForPageToLoad('.page-loading, .isLoading').then(function(){
 		document.body.style.border = "5px solid blue";
 		if(isOnAQuestionPage()){


### PR DESCRIPTION
Fixes #33 

The current state variables (currentFilter, inEditMode) are currently global (and I didn't see enough value in a refactor to change that). So that state survived between pages. This edits the method that runs with new pages to clear that state back to the default behavior. I've been unable to reproduce, and it was reliable before.