### PR TITLE
Make sure questions have been defined and added to the extension before trying to work with them

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -84,36 +84,41 @@ function isPageLoaded(selector){
 }
 
 function manipulateQuestionElements(){
+	let $questionDivs = jq('div.profile-question');
 	updateFilterCounts();
 	
 	let questionsInCategory = getQuestionsInCategory(currentFilter);
 	let questionsNotInCategory = getQuestionsNotInCategory(currentFilter);
-	jq('div.profile-question').each(function(index){
+	$questionDivs.each(function(index){
 		const thisQuestion = jq(this) // when jq.each is run, it calls the callback and sets the 'this' context when running to the DOM item
-		resetQuestionDisplay(thisQuestion);
-		const isLoaded = !thisQuestion.hasClass('isLoading');
-		if(!isLoaded){
-			thisQuestion.show();
-			return;
-		}
-		
-		const questionText = thisQuestion.find('h3').text();
-		const isUnwantedQuestion = questionsNotInCategory.includes(questionText);
-		const isWantedQuestion = questionsInCategory.includes(questionText);
-		const isUndecidedQuestion = !isUnwantedQuestion && !isWantedQuestion;
-		if(inEditMode || isUndecidedQuestion){
-			addCategorizationButtons(thisQuestion, isWantedQuestion, isUnwantedQuestion);
-			thisQuestion.css('border', `2px dashed gray`)
-
-			thisQuestion.show();
-		}
-		else if(isUnwantedQuestion){
-			thisQuestion.hide();
-		}
-		else{ // isWantedQuestion
-			thisQuestion.show();
-		}
+		manipulateQuestionElement(thisQuestion, questionsInCategory, questionsNotInCategory);
 	});
+}
+
+function manipulateQuestionElement(thisQuestion, questionsInCategory, questionsNotInCategory){
+	resetQuestionDisplay(thisQuestion);
+	const isLoaded = !thisQuestion.hasClass('isLoading');
+	if(!isLoaded){
+		thisQuestion.show();
+		return;
+	}
+	
+	const questionText = thisQuestion.find('h3').text();
+	const isUnwantedQuestion = questionsNotInCategory.includes(questionText);
+	const isWantedQuestion = questionsInCategory.includes(questionText);
+	const isUndecidedQuestion = !isUnwantedQuestion && !isWantedQuestion;
+	if(inEditMode || isUndecidedQuestion){
+		addCategorizationButtons(thisQuestion, isWantedQuestion, isUnwantedQuestion);
+		thisQuestion.css('border', `2px dashed gray`)
+
+		thisQuestion.show();
+	}
+	else if(isUnwantedQuestion){
+		thisQuestion.hide();
+	}
+	else{ // isWantedQuestion
+		thisQuestion.show();
+	}
 }
 
 function resetQuestionDisplay(questionElement){

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -83,8 +83,19 @@ function isPageLoaded(selector){
 	return jq(selector).length === 0;
 }
 
+function verifyAllQuestionsAreDefined($questionDivs){
+	$questionDivs.each(function(index){
+		const thisQuestion = jq(this);
+		const questionText = thisQuestion.find('h3').text();
+		if(getQuestionByText(questions, questionText) === undefined){
+			addQuestion(questions, questionText);
+		}
+	});
+}
+
 function manipulateQuestionElements(){
 	let $questionDivs = jq('div.profile-question');
+	verifyAllQuestionsAreDefined($questionDivs);
 	updateFilterCounts();
 	
 	let questionsInCategory = getQuestionsInCategory(currentFilter);
@@ -414,12 +425,7 @@ function getQuestions(){
 }
 
 function getQuestionByText(questions, text){
-	let question = questions.find(q => q.QuestionText === text);
-	if(!question){
-		question = addQuestion(questions, text);
-		saveQuestions(questions);
-	}
-	return question;
+	return questions.find(q => q.QuestionText === text);
 }
 
 function getQuestionsInCategory(category){
@@ -457,6 +463,7 @@ function addQuestion(questions, questionText){
 	let newQuestion = {};
 	newQuestion["QuestionText"] = questionText;
 	questions.push(newQuestion);
+	saveQuestions(questions);
 	return newQuestion;
 }
 


### PR DESCRIPTION
Fixes #35 

If a question was encountered that wasn't already defined in storage, (or at least in the questions object in memory, probably storage pending), it used to get saved when we tried to manipulate the undecided question. (But first I think it would have been miscounted for filter count purposes.) But #30 broke that while taking custom logic out of the different question types. It moved it to any time we got a question by text, but that's actually rare: only when a categorization decision is made. But the question was in a less-than-undecided state for a while.

I don't think #35 was the only bug. I'm pretty sure the question counts didn't behave right either until the question was defined. Different methods acted up in different ways, but basically a question element on screen wasn't necessarily contributing to the undecided count, or the lists of questions in various states. Those lists depended on knowing the state of each question on the screen. This specific version of the core bug was that the default filters didn't know the question was desired because it depended on those lists knowing the question existed. So it ended up as undecided instead of desired, despite being on the default no-filters that should display everything.