### PR TITLE
Formalize attribution for third party content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@
 
 Info to be written later. Basically, this is going to allow questions in OKCupid to be assigned to categories and then there will be buttons to filter the list to those categories.
 
+## External resources used ##
+
+Icons made by [Freepik](https://www.freepik.com "Freepik") from [www.flaticon.com](https://www.flaticon.com/ "Flaticon")
+jQuery 3.5.1
+Underscore.js 1.12

--- a/doc/AMODescription.txt
+++ b/doc/AMODescription.txt
@@ -1,0 +1,9 @@
+Just so we have it in version control, the following is the text that should be manually copy/pasted into the description and related fields when submitting to addons.mozilla.org:
+
+
+
+## External resources used ##
+
+Icons made by [Freepik](https://www.freepik.com "Freepik") from [www.flaticon.com](https://www.flaticon.com/ "Flaticon")
+jQuery 3.5.1
+Underscore.js 1.12

--- a/thingsThatMightNeedCredit.txt
+++ b/thingsThatMightNeedCredit.txt
@@ -1,7 +1,0 @@
-https://www.flaticon.com/free-icon/archer_4082463?term=arrow&page=2&position=74&page=2&position=74&related_id=4082463&origin=search
-
-Will need attribution if I ever do anything with this.
-
-
-
-I am also copying in jquery, PapaParse and underscore. All are under the MIT license. If I understand correctly, as long as I don't touch the copyright headers in the files, I'm free to do what I want with them.


### PR DESCRIPTION
Puts attribution for icon into github readme and firefox addons.mozilla.org page. Mentions use of jquery/underscore libraries. Removes the glorified todo doc.