### PR TITLE
Reset the page after the current filter is deleted

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -245,6 +245,12 @@ function addDeleteFilterButton(){
 				let correctlyCasedFilterName = $filterElement.children(`.profile-questions-filter-title`).first().text();
 				removeFilterButtonFromScreen($filterElement);
 				deleteFilterFromQuestions(correctlyCasedFilterName);
+				
+				if(currentFilter === correctlyCasedFilterName){
+					currentFilter = undefined;
+					inEditMode = false;
+					manipulateQuestionElements();
+				}
 			}
 			else{
 				alert(`Unable to find filter named ${deleteFilterName}`);


### PR DESCRIPTION
If the user has a filter selected and is viewing a subset of the page, the delete button is capable of removing the filter from memory and the filter list on the left. But it didn't previously refresh the page beyond removing that one element. So the filter was still in effect, and questions may have been asking for classification. This resets the page to go back to the full list of questions and no selected filter.