### PR TITLE
Restore filter buttons to page

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -180,7 +180,7 @@ function questionDoesNotBelongInFilter(thisQuestion){
 
 function listenForQuestionListUpdates(){
 	// Thanks to https://stackoverflow.com/a/42805882/1541186 for the approach here
-	var target = document.querySelector('div.profile-questions');
+	var target = document.querySelector('div.profile-questions-filters');
 	var observer = new MutationObserver(function(mutations) {
 		manipulateQuestionElements();
 	});


### PR DESCRIPTION
Fixes #47 

Simple bug, simple fix. OKCupid has apparently updated their code to rename the `profile-questions` div to now be `profile-questions-filters`. This also fixes an exception I was seeing in the console (TypeError: MutationObserver.observe: Argument 1 is not an object. filter.js:188:11)

Note that this does not fix overall functionality. The filter panel is back, but they still don't operate correctly. I need to write another bug for that.