### PR TITLE
Fix hiding/showing/editing questions

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -41,7 +41,7 @@ function manipulatePage(){
 	inEditMode = false;
 	waitForPageToLoad('.page-loading, .isLoading').then(function(){
 		if(isOnAQuestionPage()){
-			listenForQuestionListUpdates();
+			listenForQuestionUpdates();
 			createFilterButtons();
 			manipulateQuestionElements();
 		}
@@ -178,13 +178,16 @@ function questionDoesNotBelongInFilter(thisQuestion){
 	manipulateQuestionElements();
 }
 
-function listenForQuestionListUpdates(){
+function listenForQuestionUpdates(){
 	// Thanks to https://stackoverflow.com/a/42805882/1541186 for the approach here
 	var target = document.querySelector('div.profile-questions-filters');
 	var observer = new MutationObserver(function(mutations) {
 		manipulateQuestionElements();
 	});
 	var config = { childList: true};
+	observer.observe(target, config);
+	
+	target = document.querySelector('.profile-questions');
 	observer.observe(target, config);
 }
 

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -76,8 +76,8 @@ function isPageLoaded(selector){
 	return jq(selector).length === 0;
 }
 
-function verifyAllQuestionsAreDefined($questionDivs){
-	$questionDivs.each(function(index){
+function verifyAllQuestionsAreDefined($questionElements){
+	$questionElements.each(function(index){
 		const thisQuestion = jq(this);
 		const questionText = thisQuestion.find('h3').text();
 		if(getQuestionByText(questions, questionText) === undefined){
@@ -87,13 +87,13 @@ function verifyAllQuestionsAreDefined($questionDivs){
 }
 
 function manipulateQuestionElements(){
-	let $questionDivs = jq('div.profile-question');
-	verifyAllQuestionsAreDefined($questionDivs);
+	let $questionElements = jq('.profile-question');
+	verifyAllQuestionsAreDefined($questionElements);
 	updateFilterCounts();
 	
 	let questionsInCategory = getQuestionsInCategory(currentFilter);
 	let questionsNotInCategory = getQuestionsNotInCategory(currentFilter);
-	$questionDivs.each(function(index){
+	$questionElements.each(function(index){
 		const thisQuestion = jq(this) // when jq.each is run, it calls the callback and sets the 'this' context when running to the DOM item
 		manipulateQuestionElement(thisQuestion, questionsInCategory, questionsNotInCategory);
 	});
@@ -385,7 +385,7 @@ function getNumberOfQuestionsInSelectedDefaultFilter(){
 
 // Number of questions that would be on screen if the extension weren't present
 function getNumberOfLoadedQuestionsFromUser(){
-	return jq('div.profile-question').length;
+	return jq('.profile-question').length;
 }
 
 // Number of questions that are still offscreen. -1 if we don't know the size of the currently loaded page.
@@ -404,7 +404,7 @@ function getNumberOfUnloadedQuestionsFromUser(){
 
 function getNumberOfLoadedQuestionsInCategory(questionsInCategory){
 	let count = 0;
-	jq('div.profile-question').each(function(index){
+	jq('.profile-question').each(function(index){
 		const thisQuestion = jq(this);
 		const questionText = thisQuestion.find('h3').text();
 		if(questionsInCategory.includes(questionText)){


### PR DESCRIPTION
Fixes #50

Updates the selectors used to find the question elements. OKCupid has apparently changed the HTML so they're no longer divs.

Something also changed in how the page DOM updates. Loading more questions somehow used to trigger changes to the filter list, and no longer does. I added listening to the question list in addition to the filter list.