### PR TITLE
Super simple build script

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,2 @@
+set version=%1
+"C:\Program Files\7-Zip\7z.exe" a OKCupidFilterExtension_%version%.zip background_scripts content_scripts icons lib manifest.json README.md


### PR DESCRIPTION
Fixes #48 

A simple build script. Require 7-zip installed and run as:
`build.bat x.y.z` where that's a version number put into the zip file name.
This can obviously be improved at a later date. I just needed a simple way to remember what goes into the zip file, and automation is nice.