### PR TITLE
Remove duplicate filter controls by only adding them when switching profiles

### DIFF
--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -40,7 +40,7 @@ function manipulatePage(){
 	currentFilter = undefined;
 	inEditMode = false;
 	waitForPageToLoad('.page-loading, .isLoading').then(function(){
-		if(isOnAQuestionPage()){
+		if(isOnAQuestionPage(window.location.href)){
 			listenForQuestionUpdates();
 			createFilterButtons();
 			manipulateQuestionElements();
@@ -49,14 +49,35 @@ function manipulatePage(){
 }
 
 let currentUrl = location.href;
+let currentProfile = undefined;
 function listenForPageChanges(){
 	// Thanks to https://stackoverflow.com/a/1930942
 	setInterval(function() {
 		if(window.location.href != currentUrl) {
 			currentUrl = window.location.href;
-			manipulatePage();
+			
+			if(isOnAQuestionPage(currentUrl)){
+				let newProfile = getProfileFromUrl(currentUrl);
+				if(newProfile != currentProfile){
+					currentProfile = newProfile;
+					manipulatePage();
+				}
+			}
+			else{
+				currentProfile = undefined;
+			}
 		}
 	}, 3000);
+}
+
+function getProfileFromUrl(href){
+	let pathnameParts = href.split('/');
+	let profileIndex = pathnameParts.indexOf('profile')
+	if(profileIndex == -1){
+		return null;
+	}
+	let profileNameIndex = profileIndex + 1;
+	return pathnameParts[profileNameIndex];
 }
 
 async function waitForPageToLoad(selector){
@@ -474,8 +495,8 @@ function isOnPublicFilter(){
 	return Number(filterId) === 1;
 }
 
-function isOnAQuestionPage(){
-	return window.location.href.includes("/questions");
+function isOnAQuestionPage(href){
+	return href.includes("/questions");
 }
 
 })();

--- a/content_scripts/filter.js
+++ b/content_scripts/filter.js
@@ -496,7 +496,7 @@ function isOnPublicFilter(){
 }
 
 function isOnAQuestionPage(href){
-	return href.includes("/questions");
+	return href.includes("/questions") && !href.includes("questionsearch");
 }
 
 })();


### PR DESCRIPTION
Fixes #56 

We previously added the add/edit/delete filter controls whenever the URL changed, but lately that's been happening when switching between the default filters. (This previously happened dynamically without modifying the URL or triggering the extension code.) This adds some additional logic to not add our filter controls when the user never actually left the question screen. If they go back to the main profile or other pages, and then come to a new question page, we'll add our filter controls then.